### PR TITLE
allow integers to be passed as function pointers

### DIFF
--- a/examples/closure-opaque.pl
+++ b/examples/closure-opaque.pl
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use FFI::Platypus::Declare
+  'int', 'void', 'string',
+  ['(int)->int' => 'closure_t'];
+
+lib './closure.so';
+lib undef; # for puts
+
+attach set_closure => [closure_t] => void;
+attach call_closure => [int] => int;
+attach puts => [string] => int;
+
+my $closure = closure { $_[0] * 6 };
+my $opaque = cast closure_t => 'opaque', $closure;
+set_closure($opaque);
+puts(call_closure(2)); # prints "12"

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -319,7 +319,7 @@
       {
         if(!SvROK(arg))
         {
-          ffi_pl_arguments_set_pointer(arguments, i, NULL);
+          ffi_pl_arguments_set_pointer(arguments, i, SvOK(arg) ? INT2PTR(void*, SvIV(arg)) : NULL);
         }
         else
         {

--- a/t/ffi_platypus_cast.t
+++ b/t/ffi_platypus_cast.t
@@ -38,7 +38,7 @@ subtest 'cast from pointer to string' => sub {
 };
 
 subtest 'cast closure to opaque' => sub {
-  plan tests => 2;
+  plan tests => 4;
 
   my $testname = 'dynamic';
 
@@ -48,10 +48,16 @@ subtest 'cast closure to opaque' => sub {
   $ffi->function(string_set_closure => ['opaque'] => 'void')->call($pointer);
   $ffi->function(string_call_closure => ['string'] => 'void')->call("testvalue");
 
+  $ffi->function(string_set_closure => ['(string)->void'] => 'void')->call($pointer);
+  $ffi->function(string_call_closure => ['string'] => 'void')->call("testvalue");
+
   $ffi->attach_cast('cast3', '(string)->void' => 'opaque');
   my $pointer2 = cast3($closure);
 
   $testname = 'static';
   $ffi->function(string_set_closure => ['opaque'] => 'void')->call($pointer2);
+  $ffi->function(string_call_closure => ['string'] => 'void')->call("testvalue");
+
+  $ffi->function(string_set_closure => ['(string)->void'] => 'void')->call($pointer2);
   $ffi->function(string_call_closure => ['string'] => 'void')->call("testvalue");
 };


### PR DESCRIPTION
This one-liner lets you pass opaque pointers (which are integers, right?) directly instead of FFI::Platypus::Closure objects, without requiring you to change the function signature.