### PR TITLE
Cache and reuse FFI closures generated for a FFI::Platypus::Closure

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - You can now pass an opaque in place of a closure type.
+  - FFI closures are now cached and can be reused if the same closure is passed
+    repeatedly.
 
 0.29      2015-02-24 08:50:34 -0500
   - Delayed loading of Win32::ErrorMode to avoid build prereq failure on Windows

--- a/include/ffi_platypus.h
+++ b/include/ffi_platypus.h
@@ -129,7 +129,7 @@ typedef struct _ffi_pl_function {
 typedef struct _ffi_pl_closure {
   ffi_closure *ffi_closure;
   void *function_pointer; /* C function pointer */
-  void *coderef;          /* Perl CV* pointing to code ref */
+  void *coderef;          /* Perl HV* pointing to FFI::Platypus::Closure object */
   ffi_pl_type *type;
 } ffi_pl_closure;
 

--- a/include/ffi_platypus_guts.h
+++ b/include/ffi_platypus_guts.h
@@ -6,6 +6,7 @@ extern "C" {
 
 void ffi_pl_closure_call(ffi_cif *, void *, void **, void *);
 void ffi_pl_closure_add_data(SV *closure, ffi_pl_closure *closure_data);
+ffi_pl_closure *ffi_pl_closure_get_data(SV *closure, ffi_pl_type *type);
 SV*  ffi_pl_custom_perl(SV*,SV*,int);
 void ffi_pl_custom_perl_cb(SV *, SV*, int);
 HV *ffi_pl_get_type_meta(ffi_pl_type *);

--- a/libtest/closure.c
+++ b/libtest/closure.c
@@ -1,0 +1,30 @@
+#include "libtest.h"
+
+typedef int (*closure1_t)(void);
+typedef int (*closure2_t)(int);
+static closure1_t my_closure1;
+static closure2_t my_closure2;
+
+EXTERN void
+closure_set_closure1(closure1_t closure)
+{
+  my_closure1 = closure;
+}
+
+EXTERN void
+closure_set_closure2(closure2_t closure)
+{
+  my_closure2 = closure;
+}
+
+EXTERN int
+closure_call_closure1(void)
+{
+  return my_closure1();
+}
+
+EXTERN int
+closure_call_closure2(int arg)
+{
+  return my_closure2(arg);
+}

--- a/t/closure_reuse.t
+++ b/t/closure_reuse.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use FFI::CheckLib;
+use FFI::Platypus::Declare qw( void int );
+
+lib find_lib lib => 'test', symbol => 'f0', libpath => 'libtest';
+
+my $closure = closure {
+  if (@_) {
+    return $_[0] * 7;
+  }
+  return 21;
+};
+
+attach [closure_set_closure1 => 'set_closure1'] => ['()->int'] => void;
+attach [closure_set_closure2 => 'set_closure2'] => ['(int)->int'] => void;
+attach [closure_call_closure1 => 'call_closure1'] => [] => int;
+attach [closure_call_closure2 => 'call_closure2'] => [int] => int;
+
+set_closure1($closure);
+set_closure2($closure);
+
+is call_closure1(), 21;
+is call_closure2(42), 294;

--- a/t/ffi_platypus_closure.t
+++ b/t/ffi_platypus_closure.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 6;
 use FFI::Platypus;
 
 my $ffi = FFI::Platypus->new;
@@ -8,3 +8,12 @@ my $ffi = FFI::Platypus->new;
 my $closure = $ffi->closure(sub { $_[0] + 1});
 isa_ok $closure, 'FFI::Platypus::Closure';
 is $closure->(1), 2, 'closure.(1) = 2';
+
+my $c = sub { $_[0] + 2 };
+$closure = $ffi->closure($c);
+isa_ok $closure, 'FFI::Platypus::Closure';
+is $closure->(1), 3, 'closure.(1) = 3';
+
+$closure = $ffi->closure($c);
+isa_ok $closure, 'FFI::Platypus::Closure';
+is $closure->(1), 3, 'closure.(1) = 3';

--- a/xs/closure.c
+++ b/xs/closure.c
@@ -19,10 +19,39 @@ ffi_pl_closure_add_data(SV *closure, ffi_pl_closure *closure_data)
   PUSHMARK(SP);
   XPUSHs(closure);
   XPUSHs(sv_2mortal(newSViv(PTR2IV(closure_data))));
+  XPUSHs(sv_2mortal(newSViv(PTR2IV(closure_data->type))));
   PUTBACK;
   call_pv("FFI::Platypus::Closure::add_data", G_DISCARD);
   FREETMPS;
   LEAVE;
+}
+
+ffi_pl_closure *
+ffi_pl_closure_get_data(SV *closure, ffi_pl_type *type)
+{
+  dSP;
+  int count;
+  ffi_pl_closure *ret;
+
+  ENTER;
+  SAVETMPS;
+  PUSHMARK(SP);
+  XPUSHs(closure);
+  XPUSHs(sv_2mortal(newSViv(PTR2IV(type))));
+  PUTBACK;
+  count = call_pv("FFI::Platypus::Closure::get_data", G_SCALAR);
+  SPAGAIN;
+
+  if (count != 1)
+    ret = NULL;
+  else
+    ret = INT2PTR(void*, POPi);
+
+  PUTBACK;
+  FREETMPS;
+  LEAVE;
+
+  return ret;
 }
 
 void
@@ -36,6 +65,7 @@ ffi_pl_closure_call(ffi_cif *ffi_cif, void *result, void **arguments, void *user
   int i;
   int count;
   SV *sv;
+  SV **svp;
 
   if(!(flags & G_NOARGS))
   {
@@ -137,7 +167,11 @@ ffi_pl_closure_call(ffi_cif *ffi_cif, void *result, void **arguments, void *user
     PUTBACK;
   }
 
-  count = call_sv(closure->coderef, flags | G_EVAL);
+  svp = hv_fetch((HV *)SvRV((SV *)closure->coderef), "code", 4, 0);
+  if (svp)
+    count = call_sv(*svp, flags | G_EVAL);
+  else
+    count = 0;
 
   if(SvTRUE(ERRSV))
   {


### PR DESCRIPTION
I think this patch implements your suggestion for caching closures based on their ffi_pl_type *. Since that's what we also use in ffi_pl_closure_call, we should not introduce any new problems, though I'm not sure how it is guaranteed the ffi_pl_type * won't be freed while our closure is alive. Or do we never free those (as long as the FFI object is alive)?

As mentioned on #40, I've converted the FFI::Platypus::Closure code to use hashref objects with an overloaded call operator rather than blessed code refs and the inside-out table we previously had.

I believe all changes should be transparent to the user, so no documentation updates are necessary.