### PR TITLE
Multiple custom arguments/custom arguments followed by other arguments

### DIFF
--- a/lib/FFI/Platypus.xs
+++ b/lib/FFI/Platypus.xs
@@ -27,7 +27,7 @@ XS(ffi_pl_sub_call)
   ffi_pl_function *self;
   char *buffer;
   size_t buffer_size;
-  int i,n;
+  int i,n,delta;
   SV *arg;
   ffi_pl_result result;
   ffi_pl_arguments *arguments;

--- a/libtest/memcmp4.c
+++ b/libtest/memcmp4.c
@@ -1,0 +1,9 @@
+#include <string.h>
+
+int memcmp4(void *buf1, size_t n1, void *buf2, size_t n2)
+{
+  if (n1 != n2)
+    return 1;
+
+  return memcmp(buf1, buf2, n1);
+}

--- a/t/ffi_platypus_type_pointer_size_buffer.t
+++ b/t/ffi_platypus_type_pointer_size_buffer.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
-use Test::More tests => 1;
+use Test::More tests => 3;
+use FFI::CheckLib;
 use FFI::Platypus::Memory qw( malloc );
 use FFI::Platypus::Declare
   qw( void opaque string ),
@@ -18,3 +19,12 @@ memcpy($pointer, $string);
 my $string2 = cast opaque => string, $pointer;
 
 is $string2, 'luna park';
+
+lib find_lib lib => 'test', symbol => 'f0', libpath => 'libtest';
+
+attach memcmp4 => ['buffer_t', 'buffer_t'] => 'int';
+
+my $str1 = "test";
+my $str2 = "test2";
+is !!memcmp4($str1, $str2), 1;
+is memcmp4($str1, $str1), 0;

--- a/t/ffi_platypus_type_pointer_size_buffer.t
+++ b/t/ffi_platypus_type_pointer_size_buffer.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 5;
 use FFI::CheckLib;
 use FFI::Platypus::Memory qw( malloc );
 use FFI::Platypus::Declare
@@ -19,6 +19,11 @@ memcpy($pointer, $string);
 my $string2 = cast opaque => string, $pointer;
 
 is $string2, 'luna park';
+
+attach snprintf => ['buffer_t', string ] => 'int';
+
+is snprintf($string2, "this is a very long string"), 26;
+is $string2, "this is \000";
 
 lib find_lib lib => 'test', symbol => 'f0', libpath => 'libtest';
 

--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -74,6 +74,8 @@ new(class, platypus, address, abi, return_type, ...)
           self->argument_types[n+j] = self->argument_types[n];
           ffi_argument_types[n+j] = self->argument_types[n]->ffi_type;
         }
+
+        n += self->argument_types[n]->extra[0].custom_perl.argument_count;
       }
     }
     
@@ -109,7 +111,7 @@ call(self, ...)
   PREINIT:
     char *buffer;
     size_t buffer_size;
-    int i, n;
+    int i, n, delta;
     SV *arg;
     ffi_pl_result result;
     ffi_pl_arguments *arguments;


### PR DESCRIPTION
I noticed the apparent omission of 
```perl
n += self->argument_types[n]->extra[0].custom_perl.argument_count;
```

in File.xs, and tried to construct a test case that breaks because of it: multiple custom perl arguments (with argument counts > 1) cause a segfault, and so does snprintf if bound with the signature ['buffer_t', 'string'] => 'int'. Fixing the former required a few more changes than that one line.

All tests pass on this branch, including the two new ones, but it's possible I messed up somewhere in ffi_platypus_call.h and got a sign wrong.