### PR TITLE
fix compiler warning

### DIFF
--- a/xs/Function.xs
+++ b/xs/Function.xs
@@ -130,7 +130,7 @@ attach(self, perl_name, path_name, proto)
     CV* cv;
   CODE:
     if(!(sv_isobject(self) && sv_derived_from(self, "FFI::Platypus::Function")))
-      croak(aTHX_ "self is not of type FFI::Platypus::Function");
+      croak("self is not of type FFI::Platypus::Function");
 
     if(path_name == NULL)
       path_name = "unknown";


### PR DESCRIPTION
This one should be fairly obvious, though I think it's only an issue with threaded Perl.