### PR TITLE
Support checking FFI::Platypus::Function in bool context

### DIFF
--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1036,6 +1036,11 @@ use overload '&{}' => sub {
   sub { $ffi->call(@_) };
 };
 
+use overload 'bool' => sub {
+  my $ffi = shift;
+  return $ffi;
+};
+
 package FFI::Platypus::Closure;
 
 use Scalar::Util qw( refaddr);

--- a/t/ffi_platypus_ignore_not_found.t
+++ b/t/ffi_platypus_ignore_not_found.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 6;
 use FFI::Platypus;
 use FFI::CheckLib;
 
@@ -108,4 +108,17 @@ subtest 'ignore_not_found=1 (constructor)' => sub {
   
   eval { $ffi->attach(bogus => [] => 'void') };
   is $@, '', 'attach no exception';
+};
+
+subtest 'ignore_not_found bool context' => sub {
+  plan tests => 2;
+
+  my $ffi = FFI::Platypus->new( ignore_not_found => 1 );
+  $ffi->lib($lib);
+
+  my $f1 = eval { $ffi->function(f1 => [] => 'void') };
+  ok $f1, 'f1 exists and resolved to boolean true';
+
+  my $f2 = eval { $ffi->function(bogus => [] => 'void') };
+  ok !$f2, 'f2 does not exist and resolved to boolean false';
 };


### PR DESCRIPTION
e.g.

```perl
$ffi->ignore_not_found(1);
my $function = $ffi->function('zmq_version' => [qw(int* int* int*)] => 'void');
if ($function) {
    # do something
}
else {
    # do something else
}
```

which currently explodes with
```
Operation "bool": no method found, argument in overloaded package FFI::Platypus::Function
```

Thanks