### PR TITLE
Avoid unnecessary downgrade on when NV==longdouble

### DIFF
--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -1214,7 +1214,7 @@
           }
           else
           {
-            XSRETURN_NV((double) result.longdouble);
+            XSRETURN_NV((NV) result.longdouble);
           }
         }
 #endif


### PR DESCRIPTION
This fixes loss of precision in return value on Perls built with -Duselongdouble when Math::LongDouble is not installed.