### PR TITLE
Make the build reproducible

### DIFF
--- a/inc/My/ShareConfig.pm
+++ b/inc/My/ShareConfig.pm
@@ -34,7 +34,7 @@ sub set
   my($self, $name, $value) = @_;
   $self->{$name} = $value;
   my %data = %$self;
-  my $data = JSON::PP->new->pretty->encode(\%data);
+  my $data = JSON::PP->new->canonical->pretty->encode(\%data);
   my $fh;
   open($fh, '>', 'share/config.json');
   print $fh $data;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
FFI-Platypus.
We thought you might be interested in it too.

    Description: Make the build reproducible
      Whilst working on the Reproducible Builds effort [0], we noticed
      that libffi-platypus-perl could not be built reproducibly.
      .
      This is because it rendered JSON without calling "canonical" to ensure
      determinsitic sorting which ended up in a "config.json" file.
      .
      [0] https://reproducible-builds.org/
    Author: Chris Lamb <lamby@debian.org>
    Acked-By: Damyan Ivanov <dmn@debian.org>
    Last-Update: 2017-11-26

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libffi-platypus-perl.git/plain/debian/patches/reproducible-build.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
