### PR TITLE
fix typo in FFI::Platypus::Buffer SYNOPSIS

### DIFF
--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -13,7 +13,7 @@ our @EXPORT = qw( scalar_to_buffer buffer_to_scalar );
 
  use FFI::Platypus::Buffer;
  my($pointer, $size) = scalar_to_buffer $scalar;
- my $scalar2 = buffer_to_scallar $pointer, $size;
+ my $scalar2 = buffer_to_scalar $pointer, $size;
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Hello.

fix typo in FFI::Platypus::Buffer SYNOPSIS: buffer_to_scallar -> buffer_to_scalar

Best Regards, Ilya Pavlov