### PR TITLE
fix typo in FFI::Platypus::Record SYNOPSIS

### DIFF
--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -37,7 +37,7 @@ Perl:
    int       age
    string(3) title
    string_rw name
- );
+ ));
  
  package main;
  


### PR DESCRIPTION
Hello.

fix typo in FFI::Platypus::Record SYNOPSIS
missing right bracket ')'

Best Regards, Ilya Pavlov